### PR TITLE
Deployed PGADMIN service. Resolves #27

### DIFF
--- a/deployment/docker_compose/docker-compose.dev.yml
+++ b/deployment/docker_compose/docker-compose.dev.yml
@@ -283,6 +283,8 @@ services:
        - pgadmin:/var/lib/pgadmin
     ports:
       - "${PGADMIN_PORT:-5050}:80"
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     restart: unless-stopped
 
   # This container name cannot have an underscore in it due to Vespa expectations of the URL

--- a/deployment/docker_compose/docker-compose.dev.yml
+++ b/deployment/docker_compose/docker-compose.dev.yml
@@ -270,7 +270,20 @@ services:
       - "5432:5432"
     volumes:
       - db_volume:/var/lib/postgresql/data
-
+  
+  pgadmin:
+    image: dpage/pgadmin4
+    environment:
+      PGADMIN_DEFAULT_EMAIL: ${PGADMIN_DEFAULT_EMAIL:-pgadmin4@pgadmin.org}
+      PGADMIN_DEFAULT_PASSWORD: ${PGADMIN_DEFAULT_PASSWORD:-admin}
+      PGADMIN_CONFIG_SERVER_MODE: 'False'
+    depends_on:
+      - relational_db
+    volumes:
+       - pgadmin:/var/lib/pgadmin
+    ports:
+      - "${PGADMIN_PORT:-5050}:5050"
+    restart: unless-stopped
 
   # This container name cannot have an underscore in it due to Vespa expectations of the URL
   index:
@@ -325,6 +338,7 @@ volumes:
   # file_connector_tmp_storage is legacy only now
   file_connector_tmp_storage:
   db_volume:
+  pgadmin:
   vespa_volume:
   # Created by the container itself
   model_cache_huggingface:

--- a/deployment/docker_compose/docker-compose.dev.yml
+++ b/deployment/docker_compose/docker-compose.dev.yml
@@ -282,7 +282,7 @@ services:
     volumes:
        - pgadmin:/var/lib/pgadmin
     ports:
-      - "${PGADMIN_PORT:-5050}:5050"
+      - "${PGADMIN_PORT:-5050}:80"
     restart: unless-stopped
 
   # This container name cannot have an underscore in it due to Vespa expectations of the URL


### PR DESCRIPTION
- Added PGADMIN to development environment only. 
- Use `host.docker.internal `as host to connect to the DB
- Use postgres user and password specified in docker compose file.